### PR TITLE
Stop recompressing before caching, fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,10 +462,6 @@ installPurescript({
 			task.message = `${event.version} found at ${event.path}`;
 			return;
 		}
-
-		if (event.id === 'write-cache') {
-			task.message = `It takes a while to convert the ${filesize(event.originalSize, filesizeOptions)} binary into a few MB cache.`;
-		}
 	},
 	error(err) {
 		clearInterval(loop);

--- a/install-purescript/README.md
+++ b/install-purescript/README.md
@@ -205,12 +205,11 @@ Inherited from [`build-purescript`](https://github.com/shinnn/build-purescript#e
 
 ##### `write-cache`
 
-Fires when it starts to create a cache. The cache is compressed with [Brotli](https://github.com/google/brotli).
+Fires when it starts to create a cache.
 
 ```javascript
 {
   id: 'write-cache',
-  originalSize: <integer> // the size of the binary before compression in bytes
 }
 ```
 

--- a/install-purescript/index.js
+++ b/install-purescript/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const {constants: {BROTLI_PARAM_SIZE_HINT}, brotliCompress, createBrotliDecompress} = require('zlib');
-const {createReadStream, lstat, stat} = require('fs');
+const fs = require('fs');
 const {execFile} = require('child_process');
 const {join, normalize} = require('path');
 const {promisify} = require('util');
@@ -9,7 +8,7 @@ const {Writable} = require('stream');
 
 const arch = require('arch');
 const {create, Unpack} = require('tar');
-const {get: {info: getCacheInfo}, put: putCache, rm: {entry: removeCache}, tmp: {withTmp}, verify} = require('npcache');
+const {get: {info: getCacheInfo}, put: { stream: putCacheStream }, rm: {entry: removeCache}, tmp: {withTmp}, verify} = require('npcache');
 const inspectWithKind = require('inspect-with-kind');
 const isPlainObj = require('is-plain-obj');
 const Observable = require('zen-observable');
@@ -94,54 +93,21 @@ module.exports = function installPurescript(...args) {
 					observer.error(err);
 				},
 				async complete() {
-					const writeCacheValue = {id: 'write-cache'};
-					const tarBuffers = [];
-					const tarCreateOptions = {
-						cwd,
-						maxReadSize: MAX_READ_SIZE,
-						noDirRecurse: true,
-						strict: true,
-						statCache: new Map()
-					};
-					let tarSize = 0;
+					observer.next({id: 'write-cache'});
 
 					try {
-						const binStat = await promisify(lstat)(binPath);
-
-						tarCreateOptions.statCache.set(binPath, binStat);
-						writeCacheValue.originalSize = binStat.size;
-					} catch {}
-
-					observer.next(writeCacheValue);
-
-					try {
-						await Promise.all([
-							promisify(pump)(create(tarCreateOptions, [binName]), new Writable({
-								write(data, _, cb) {
-									tarBuffers.push(data);
-									tarSize += data.length;
-									cb();
-								}
-							})),
-							(async () => {
-								await cacheCleaning;
-
-								// Ensure the path where the current npm config regards as a cache directory
-								// is actually available, before performing long-running compression
-								await withTmp(async () => {});
-							})()
-						]);
-						const decomressed = await promisify(brotliCompress)(Buffer.concat(tarBuffers, tarSize), {
-							params: {
-								[BROTLI_PARAM_SIZE_HINT]: tarSize
-							}
-						});
-						await putCache(CACHE_KEY, decomressed, {
-							size: decomressed.size,
+						await cacheCleaning;
+						const binStat = await promisify(fs.lstat)(binPath);
+						const cacheStream = await putCacheStream(CACHE_KEY, {
+							size: binStat.size,
 							metadata: {
-								id: cacheId
+								id: cacheId,
+								mode: binStat.mode
 							}
 						});
+						await promisify(pump)(
+							fs.createReadStream(binPath),
+							cacheStream);
 					} catch (err) {
 						observer.next({
 							id: 'write-cache:fail',
@@ -176,6 +142,7 @@ module.exports = function installPurescript(...args) {
 			};
 			let id;
 			let cachePath;
+			let binMode;
 
 			try {
 				const [info] = await Promise.all([
@@ -185,20 +152,30 @@ module.exports = function installPurescript(...args) {
 						tmpSubscription.unsubscribe();
 					})(),
 					(async () => {
+						let binStat;
 						try {
-							if ((await promisify(stat)(binPath)).isDirectory()) {
+							binStat = await promisify(fs.stat)(binPath);
+
+							if (binStat.isDirectory()) {
 								const error = new Error(`Tried to create a PureScript binary at ${binPath}, but a directory already exists there.`);
 
 								error.code = 'EISDIR';
 								error.path = binPath;
 								observer.error(error);
+							} else {
+								await promisify(fs.unlink)(binPath);
 							}
-						} catch (_) {}
+						} catch (err) {
+							if (err.code !== 'ENOENT') {
+								throw err;
+							}
+						}
 					})()
 				]);
 
 				id = info.metadata.id;
 				cachePath = info.path;
+				binMode = info.metadata.mode;
 			} catch (_) {
 				if (observer.closed) {
 					return;
@@ -226,29 +203,11 @@ module.exports = function installPurescript(...args) {
 			observer.next({id: 'restore-cache'});
 
 			try {
-				let fileCount = 0;
-
-				await promisify(pump)(createReadStream(cachePath), createBrotliDecompress(), new Unpack({
-					strict: true,
-					cwd,
-					filter(_, entry) {
-						entry.path = binName;
-						entry.header.path = binName;
-						entry.absolute = binPath;
-
-						const isFile = entry.type === 'File';
-
-						fileCount += Number(isFile);
-						return isFile;
-					}
-				}));
-
-				if (fileCount !== 1) {
-					const error = new Error(`Expected a cached PureScript binary archive ${cachePath} contains 1 file, but found ${fileCount}.`);
-
-					error.code = 'EINVALIDCACHE';
-					throw error;
-				}
+				await promisify(pump)(
+					fs.createReadStream(cachePath),
+					fs.createWriteStream(binPath)
+				);
+				await promisify(fs.chmod)(binPath, binMode);
 			} catch (err) {
 				observer.next({
 					id: 'restore-cache:fail',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "purescript-npm-installer",
-  "version": "1.0.0",
+  "name": "purescript-installer",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
As well as improving UX, this is the first step towards restoring Node
8.x support, since brotli compression is not provided in Node 8.x.