### PR TITLE
Upgrade `make-fetch-happen` to ^11.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "is-plain-obj": "^2.0.0",
     "log-symbols": "^3.0.0",
     "log-update": "^4.0.0",
-    "make-fetch-happen": "^10.0.0",
+    "make-fetch-happen": "^11.0.1",
     "minimist": "^1.2.0",
     "ms": "^2.1.2",
     "once": "^1.4.0",


### PR DESCRIPTION
To ease this warning:

```
npm WARN deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
```