### PR TITLE
Delete dubious double-download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - uses: "actions/checkout@v3"
 

--- a/install-purescript/index.js
+++ b/install-purescript/index.js
@@ -129,12 +129,6 @@ module.exports = function installPurescript(...args) {
 			return cancelInstallation;
 		}
 
-		const tmpSubscription = downloadOrBuildPurescript(options).subscribe({
-			error(err) {
-				observer.error(err);
-			}
-		});
-
 		(async () => {
 			const searchCacheValue = {
 				id: 'search-cache',
@@ -143,10 +137,6 @@ module.exports = function installPurescript(...args) {
 
 			const [info] = await Promise.all([
 				cacache.get.info(cacheRootDir, CACHE_KEY),
-				(async () => {
-					await promisify(setImmediate)();
-					tmpSubscription.unsubscribe();
-				})(),
 				(async () => {
 					let binStat;
 					try {


### PR DESCRIPTION
I can't imagine the purpose of this code that starts, and then cancels, a second download in parallel with the first. After recent changes to the internals of dl-tar, the cancellation was no longer effective, and the two download-and-extract processes ended up interfering with each other sometimes.

Removing this code seems strictly beneficial; maybe one day I'll regret this but right now I can't see a reason to keep it.

Fixes #37.