### PR TITLE
Update Purescript versions in tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -85,35 +85,28 @@ function testInstall(version, expectedEvents) {
 	});
 }
 
-tap.test('clean install', testInstall('0.13.0', [
+tap.test('clean install', testInstall('0.15.7', [
 	{ id: 'search-cache', found: false },
 	{ id: 'download-binary' },
 	{ id: 'check-binary' },
 	{ id: 'write-cache' }
 ]));
 
-tap.test('install from cache', testInstall('0.13.0', [
+tap.test('install from cache', testInstall('0.15.7', [
 	{ id: 'search-cache', found: true },
 	{ id: 'restore-cache' },
 	{ id: 'check-binary' }
 ]));
 
-tap.test('install a different version', testInstall('0.12.5', [
+tap.test('install a different version', testInstall('0.15.6', [
 	{ id: 'search-cache', found: false },
 	{ id: 'download-binary' },
 	{ id: 'check-binary' },
 	{ id: 'write-cache' }
 ]));
 
-tap.test('install a different version from cache', testInstall('0.12.5', [
+tap.test('install a different version from cache', testInstall('0.15.6', [
 	{ id: 'search-cache', found: true },
 	{ id: 'restore-cache' },
 	{ id: 'check-binary' }
-]));
-
-tap.test('clean install', testInstall('0.15.0-alpha-06', [
-	{ id: 'search-cache', found: false },
-	{ id: 'download-binary' },
-	{ id: 'check-binary' },
-	{ id: 'write-cache' }
 ]));


### PR DESCRIPTION
The `0.13.0` versions used in the tests does not work anymore due to dependency on `libtinfo`. That makes the installer to try to build the binary from source. It might work for real use cases (though it failed in my Ubuntu 20.04 container) but the tests fail because of the time limit.

I updated the versions in tests to the latest ones (`0.15.x`). I also removed one test because I'm not able to see what the test is supposed to test and what version should be used there.