### PR TITLE
Support macOS and Linux ARM64 binaries

### DIFF
--- a/download-or-build-purescript/index.js
+++ b/download-or-build-purescript/index.js
@@ -13,7 +13,7 @@ const spawnStack = require('../spawn-stack/index.js');
 const which = require('which');
 
 const buildPurescript = require('../build-purescript/index.js');
-const downloadPurescript = require('../download-purescript/index.js');
+const { defaultVersion, downloadPurescript } = require('../download-purescript/index.js');
 
 function addId(obj, id) {
 	Object.defineProperty(obj, 'id', {
@@ -66,8 +66,8 @@ module.exports = function downloadOrBuildPurescript(...args) {
 			}
 		}
 
-		const version = options.version || downloadPurescript.defaultVersion;
-		const buildOptions = {revision: `v${version}`, ...options};
+		const version = options.version || defaultVersion;
+		const buildOptions = { revision: `v${version}`, ...options };
 		const binName = options.rename ? options.rename(initialBinName) : initialBinName;
 
 		if (typeof binName !== 'string') {
@@ -276,7 +276,7 @@ module.exports = function downloadOrBuildPurescript(...args) {
 Object.defineProperties(module.exports, {
 	defaultVersion: {
 		enumerable: true,
-		value: downloadPurescript.defaultVersion
+		value: defaultVersion
 	},
 	supportedBuildFlags: {
 		enumerable: true,

--- a/download-purescript-source/README.md
+++ b/download-purescript-source/README.md
@@ -8,7 +8,7 @@ A [Node.js](https://nodejs.org) module to download [PureScript](https://github.c
 
 ```javascript
 const {readdir} = require('fs').promises;
-const downloadPurescript = require('download-purescript-source');
+const { downloadPurescript } = require('download-purescript-source');
 
 downloadPurescript('./dest/').subscribe({
   async complete() {

--- a/download-purescript-source/README.md
+++ b/download-purescript-source/README.md
@@ -8,9 +8,9 @@ A [Node.js](https://nodejs.org) module to download [PureScript](https://github.c
 
 ```javascript
 const {readdir} = require('fs').promises;
-const { downloadPurescript } = require('download-purescript-source');
+const downloadPurescriptSource = require('download-purescript-source');
 
-downloadPurescript('./dest/').subscribe({
+downloadPurescriptSource('./dest/').subscribe({
   async complete() {
     await readdir('./dest/'); /*=> [
       'LICENSE',

--- a/download-purescript/README.md
+++ b/download-purescript/README.md
@@ -8,7 +8,7 @@ A [Node.js](https://nodejs.org) module to download a prebuilt [PureScript](https
 
 ```javascript
 const {readdir} = require('fs').promises;
-const downloadPurescript = require('download-purescript');
+const { downloadPurescript } = require('download-purescript');
 
 downloadPurescript().subscribe({
   async complete() {
@@ -28,7 +28,7 @@ npm install download-purescript
 ## API
 
 ```javascript
-const downloadPurescript = require('download-purescript');
+const { downloadPurescript } = require('download-purescript');
 ```
 
 ### downloadPurescript([*options*])

--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -38,14 +38,18 @@ function createUnsupportedPlatformError(buildProfile) {
   return new Observable(observer => observer.error(error));
 }
 
-module.exports = function downloadPurescript(...args) {
+function getBuildProfile() {
   let architecture = process.arch;
   // It's only defined from Node 16.18 onwards
   if (typeof os.machine === 'function') {
     architecture = os.machine();
   }
 
-  let buildProfile = `${process.platform}-${architecture}`;
+  return `${process.platform}-${architecture}`;
+}
+
+exports.downloadPurescript = function (...args) {
+  let buildProfile = getBuildProfile();
   const archiveName = supportedPlatforms.get(buildProfile);
 
   if (!archiveName) {
@@ -104,7 +108,6 @@ module.exports = function downloadPurescript(...args) {
   return dlTar(url, process.cwd(), options);
 }
 
-Object.defineProperty(module.exports, 'defaultVersion', {
-  enumerable: true,
-  value: DEFAULT_VERSION
-});
+exports.defaultVersion = DEFAULT_VERSION;
+
+exports.getBuildProfile = getBuildProfile;

--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -2,6 +2,7 @@
 
 const { basename } = require('path');
 const { inspect } = require('util');
+const os = require('os');
 const semver = require('semver');
 
 const dlTar = require('../dl-tar/index.js');
@@ -12,8 +13,10 @@ const supportedPlatforms = new Map([
   ['linux-x64', 'linux64'],
   ['darwin-x64', 'macos'],
   ['win32-x64', 'win64'],
+  ['darwin-arm64', 'macos-arm64'],
+  // on Linux os.machine returns aarch64, os.arch returns arm64...
+  ['linux-aarch64', 'linux-arm64'],
   ['linux-arm64', 'linux-arm64'],
-  ['darwin-arm64', 'macos-arm64']
 ]);
 
 const DEFAULT_VERSION = '0.15.0';
@@ -36,7 +39,13 @@ function createUnsupportedPlatformError(buildProfile) {
 }
 
 module.exports = function downloadPurescript(...args) {
-  let buildProfile = `${process.platform}-${process.arch}`;
+  let architecture = process.arch;
+  // It's only defined from Node 16.18 onwards
+  if (typeof os.machine === 'function') {
+    architecture = os.machine();
+  }
+
+  let buildProfile = `${process.platform}-${architecture}`;
   const archiveName = supportedPlatforms.get(buildProfile);
 
   if (!archiveName) {

--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -1,136 +1,101 @@
 'use strict';
 
-const {basename} = require('path');
-const {inspect} = require('util');
+const { basename } = require('path');
+const { inspect } = require('util');
 const semver = require('semver');
 
 const dlTar = require('../dl-tar/index.js');
-const getArch = require('arch');
 const isPlainObj = require('is-plain-obj');
 const Observable = require('zen-observable');
 
 const supportedPlatforms = new Map([
-	['linux', 'linux64'],
-	['darwin', 'macos'],
-	['win32', 'win64']
+  ['linux-x64', 'linux64'],
+  ['darwin-x64', 'macos'],
+  ['win32-x64', 'win64'],
+  ['linux-arm64', 'linux-arm64'],
+  ['darwin-arm64', 'macos-arm64']
 ]);
 
-const unsupportedPlatforms = new Map([
-	['aix', 'AIX'],
-	['android', 'Android'],
-	['freebsd', 'FreeBSD'],
-	['openbsd', 'OpenBSD'],
-	['sunos', 'Solaris']
-]);
-
-const DEFAULT_VERSION = '0.12.5';
+const DEFAULT_VERSION = '0.15.0';
 const VERSION_ERROR = `Expected \`version\` option to be a string of PureScript version, for example '${DEFAULT_VERSION}'`;
 const defaultOptions = {
-	filter: function isPurs(filePath) {
-		return basename(filePath, '.exe') === 'purs';
-	},
-	baseUrl: 'https://github.com/purescript/purescript/releases/download/'
+  filter: function isPurs(filePath) {
+    return basename(filePath, '.exe') === 'purs';
+  },
+  version: DEFAULT_VERSION,
+  baseUrl: 'https://github.com/purescript/purescript/releases/download/'
 };
-const arch = getArch();
 
-function createUnsupportedPlatformError() {
-	const error = new Error(`Prebuilt \`purs\` binary is not provided for ${
-		unsupportedPlatforms.get(process.platform)
-	}.`);
+function createUnsupportedPlatformError(buildProfile) {
+  const error = new Error(`Prebuilt \`purs\` binary is not provided for your combination of operating system and architecture: '${buildProfile}'.`);
 
-	error.code = 'ERR_UNSUPPORTED_PLATFORM';
-	Error.captureStackTrace(error, createUnsupportedPlatformError);
+  error.code = 'ERR_UNSUPPORTED_PLATFORM';
+  Error.captureStackTrace(error, createUnsupportedPlatformError);
 
-	return new Observable(observer => observer.error(error));
+  return new Observable(observer => observer.error(error));
 }
 
-module.exports = arch === 'x64' ? function downloadPurescript(...args) {
-	const argLen = args.length;
+module.exports = function downloadPurescript(...args) {
+  let buildProfile = `${process.platform}-${process.arch}`;
+  const archiveName = supportedPlatforms.get(buildProfile);
 
-	if (argLen === 0) {
-		const archiveName = supportedPlatforms.get(process.platform);
+  if (!archiveName) {
+    return createUnsupportedPlatformError(buildProfile);
+  }
 
-		if (!archiveName) {
-			return createUnsupportedPlatformError();
-		}
+  if (args.length > 1) {
+    const error = new RangeError(`Expected 0 or 1 argument ([<Object>]), but got ${argLen} arguments.`);
+    error.code = 'ERR_TOO_MANY_ARGS';
+    return new Observable(observer => observer.error(error));
+  }
 
-		return dlTar(`v${DEFAULT_VERSION}/${archiveName}.tar.gz`, process.cwd(), defaultOptions);
-	} else if (argLen !== 1) {
-		const error = new RangeError(`Expected 0 or 1 argument ([<Object>]), but got ${argLen} arguments.`);
-		error.code = 'ERR_TOO_MANY_ARGS';
+  let options = defaultOptions;
 
-		return new Observable(observer => observer.error(error));
-	}
+  if (args.length === 1) {
+    const [newOptions] = args;
 
-	const [options] = args;
+    if (!isPlainObj(newOptions)) {
+      return new Observable(observer => {
+        observer.error(new TypeError(`Expected download-purescript option to be an object, but got ${inspect(newOptions)}.`));
+      });
+    }
 
-	if (!isPlainObj(options)) {
-		return new Observable(observer => {
-			observer.error(new TypeError(`Expected download-purescript option to be an object, but got ${inspect(options)}.`));
-		});
-	}
+    options = { ...defaultOptions, ...newOptions };
 
-	if (options.followRedirect !== undefined && !options.followRedirect) {
-		return new Observable(observer => observer.error(new Error('`followRedirect` option cannot be disabled.')));
-	}
+    if (options.followRedirect !== undefined && !options.followRedirect) {
+      return new Observable(observer => observer.error(new Error('`followRedirect` option cannot be disabled.')));
+    }
 
-	const {version} = options;
+    if (options.strip !== undefined && options.strip !== 1) {
+      return new Observable(observer => {
+        observer.error(new Error(`\`strip\` option is unchangeable, but ${inspect(options.strip)} was provided.`));
+      });
+    }
 
-	if (version !== DEFAULT_VERSION && version !== undefined) {
-		if (typeof version !== 'string') {
-			return new Observable(observer => {
-				observer.error(new TypeError(`${VERSION_ERROR}, but got a non-string value ${inspect(version)}.`));
-			});
-		}
+    if (options.version !== undefined) {
+      if (typeof options.version !== 'string') {
+        return new Observable(observer => {
+          observer.error(new TypeError(`${VERSION_ERROR}, but got a non-string value ${inspect(options.version)}.`));
+        });
+      }
 
-		if (version.length === 0) {
-			return new Observable(observer => {
-				observer.error(new Error(`${
-					VERSION_ERROR
-				}, but got '' (empty string). If you want to download the default version ${
-					DEFAULT_VERSION
-				}, you don't need to pass any values to \`version\` option.`));
-			});
-		}
+      if (options.version.length === 0) {
+        options.version = DEFAULT_VERSION;
+      }
 
-		if (!semver.valid(version)) {
-			return new Observable(observer => {
-				observer.error(new Error(`${VERSION_ERROR}, but got an invalid version ${inspect(version)}.`));
-			});
-		}
-	}
+      if (!semver.valid(options.version)) {
+        return new Observable(observer => {
+          observer.error(new Error(`${VERSION_ERROR}, but got an invalid version ${inspect(options.version)}.`));
+        });
+      }
+    }
+  }
 
-	if (!supportedPlatforms.has(process.platform)) {
-		return createUnsupportedPlatformError();
-	}
-
-	if (options.strip !== undefined && options.strip !== 1) {
-		return new Observable(observer => {
-			observer.error(new Error(`\`strip\` option is unchangeable, but ${
-				inspect(options.strip)
-			} was provided.`));
-		});
-	}
-
-	const url = `v${version || DEFAULT_VERSION}/${supportedPlatforms.get(process.platform)}.tar.gz`;
-
-	return dlTar(url, process.cwd(), {...defaultOptions, ...options});
-} : function downloadPurescript() {
-	if (!supportedPlatforms.has(process.platform)) {
-		return createUnsupportedPlatformError();
-	}
-
-	return new Observable(() => {
-		const error = new Error('The prebuilt PureScript binaries only support 64-bit architectures, but the current system is not 64-bit.');
-
-		error.code = 'ERR_UNSUPPORTED_ARCH';
-		error.currentArch = arch;
-
-		throw error;
-	});
-};
+  const url = `v${options.version}/${archiveName}.tar.gz`;
+  return dlTar(url, process.cwd(), options);
+}
 
 Object.defineProperty(module.exports, 'defaultVersion', {
-	enumerable: true,
-	value: DEFAULT_VERSION
+  enumerable: true,
+  value: DEFAULT_VERSION
 });

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const ms = require('ms');
 const once = require('once');
 
 const installPurescript = require('./install-purescript/index.js');
+const downloadPurescript = require('./download-purescript/index.js');
 
 const {blue, cyan, dim, magenta, red, strikethrough, underline, yellow} = chalk;
 
@@ -43,7 +44,7 @@ const argv = minimist(process.argv.slice(2), {
 		'purs-ver'
 	],
 	default: {
-		'purs-ver': '0.13.0'
+		'purs-ver': downloadPurescript.defaultVersion,
 	},
 	unknown(flag) {
 		if (!installPurescript.supportedBuildFlags.has(flag)) {
@@ -135,7 +136,7 @@ const taskGroups = [
 		[
 			'head',
 			{
-				head: `Check if a prebuilt ${cyan(argv['purs-ver'])} binary is provided for ${process.platform}`,
+				head: `Check if a prebuilt ${cyan(argv['purs-ver'])} binary is provided for ${process.platform}-${process.arch}`,
 				status: 'processing'
 			}
 		],

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const ms = require('ms');
 const once = require('once');
 
 const installPurescript = require('./install-purescript/index.js');
-const downloadPurescript = require('./download-purescript/index.js');
+const { defaultVersion, getBuildProfile } = require('./download-purescript/index.js');
 
 const {blue, cyan, dim, magenta, red, strikethrough, underline, yellow} = chalk;
 
@@ -44,7 +44,7 @@ const argv = minimist(process.argv.slice(2), {
 		'purs-ver'
 	],
 	default: {
-		'purs-ver': downloadPurescript.defaultVersion,
+		'purs-ver': defaultVersion,
 	},
 	unknown(flag) {
 		if (!installPurescript.supportedBuildFlags.has(flag)) {
@@ -136,7 +136,7 @@ const taskGroups = [
 		[
 			'head',
 			{
-				head: `Check if a prebuilt ${cyan(argv['purs-ver'])} binary is provided for ${process.platform}-${process.arch}`,
+				head: `Check if a prebuilt ${cyan(argv['purs-ver'])} binary is provided for ${getBuildProfile()}`,
 				status: 'processing'
 			}
 		],

--- a/install-purescript/index.js
+++ b/install-purescript/index.js
@@ -11,6 +11,7 @@ const Observable = require('zen-observable');
 const envPaths = require('env-paths');
 
 const downloadOrBuildPurescript = require('../download-or-build-purescript/index.js');
+const { getBuildProfile } = require('../download-purescript/index.js');
 
 function addId(obj, id) {
 	Object.defineProperty(obj, 'id', {
@@ -24,7 +25,7 @@ function addId(obj, id) {
 const defaultCacheRootDir = envPaths('purescript-npm-installer').cache;
 const CACHE_KEY = 'install-purescript:binary';
 const defaultBinName = `purs${process.platform === 'win32' ? '.exe' : ''}`;
-const cacheIdSuffix = `-${process.platform}-${process.arch}`;
+const cacheIdSuffix = `-${getBuildProfile()}`;
 
 module.exports = function installPurescript(...args) {
 	return new Observable(observer => {

--- a/install-purescript/index.js
+++ b/install-purescript/index.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const fs = require('fs');
-const {execFile} = require('child_process');
+const { execFile } = require('child_process');
 const path = require('path');
-const {inspect, promisify} = require('util');
-const {pipeline: pump} = require('stream');
-
-const arch = require('arch');
-const {create, Unpack} = require('tar');
+const { inspect, promisify } = require('util');
+const { pipeline: pump } = require('stream');
 const cacache = require('cacache');
 const isPlainObj = require('is-plain-obj');
 const Observable = require('zen-observable');
@@ -26,9 +23,8 @@ function addId(obj, id) {
 
 const defaultCacheRootDir = envPaths('purescript-npm-installer').cache;
 const CACHE_KEY = 'install-purescript:binary';
-const MAX_READ_SIZE = 30 * 1024 * 1024;
 const defaultBinName = `purs${process.platform === 'win32' ? '.exe' : ''}`;
-const cacheIdSuffix = `-${process.platform}-${arch()}`;
+const cacheIdSuffix = `-${process.platform}-${process.arch}`;
 
 module.exports = function installPurescript(...args) {
 	return new Observable(observer => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "node": ">=12"
   },
   "dependencies": {
-    "arch": "^2.1.1",
     "byline": "^5.0.0",
     "cacache": "^11.3.2",
     "chalk": "^2.4.2",


### PR DESCRIPTION
Fix #43.

This codebase is extremely frustrating. There are endless layers of indirection and it's impossible to get anything done in a reasonable amount of time.

There are over 2000 lines of JS in here, and I feel like we ought to get the job done in 100-200. I sort of want to rewrite the whole thing, but in this PR I limited myself to rewriting the module that downloads from a release to also look for ARM releases.

I ditched the dependency on the `arch` package in the process because it is a pile of code that implements the wrong thing, and we can use the builtin `process.arch` instead.

I have tested locally that this works, by running the instructions for "local development" and then running `npx install-purescript --purs-ver=0.15.9-5`.