### PR TITLE
fix for differences between os.machine() and process.arch

### DIFF
--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -13,6 +13,9 @@ const supportedPlatforms = new Map([
   ['linux-x64', 'linux64'],
   ['darwin-x64', 'macos'],
   ['win32-x64', 'win64'],
+  ['linux-x86_64', 'linux64'],
+  ['darwin-x86_64', 'macos'],
+  ['win32--x86_64', 'win64'],
   ['darwin-arm64', 'macos-arm64'],
   // on Linux os.machine returns aarch64, os.arch returns arm64...
   ['linux-aarch64', 'linux-arm64'],

--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -10,14 +10,16 @@ const isPlainObj = require('is-plain-obj');
 const Observable = require('zen-observable');
 
 const supportedPlatforms = new Map([
+  // on all OSes, os.machine returns x86_64, process.arch returns x64
   ['linux-x64', 'linux64'],
   ['darwin-x64', 'macos'],
   ['win32-x64', 'win64'],
   ['linux-x86_64', 'linux64'],
   ['darwin-x86_64', 'macos'],
   ['win32-x86_64', 'win64'],
+
   ['darwin-arm64', 'macos-arm64'],
-  // on Linux os.machine returns aarch64, os.arch returns arm64...
+  // on Linux os.machine returns aarch64, process.arch returns arm64
   ['linux-aarch64', 'linux-arm64'],
   ['linux-arm64', 'linux-arm64'],
 ]);

--- a/download-purescript/index.js
+++ b/download-purescript/index.js
@@ -15,7 +15,7 @@ const supportedPlatforms = new Map([
   ['win32-x64', 'win64'],
   ['linux-x86_64', 'linux64'],
   ['darwin-x86_64', 'macos'],
-  ['win32--x86_64', 'win64'],
+  ['win32-x86_64', 'win64'],
   ['darwin-arm64', 'macos-arm64'],
   // on Linux os.machine returns aarch64, os.arch returns arm64...
   ['linux-aarch64', 'linux-arm64'],


### PR DESCRIPTION
Hi - I pinged you on discourse - this is (I think) a possible solution to the installer problem.

there seems to be a difference between os.machine() and process.arch for x86/64 architecture - the first gives `x86_64` the later `x64`

this is a quick work around this (or so I think)